### PR TITLE
fix: Hardware acceleration settings with IPC and Settings UI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+description: Report a bug or unexpected behavior
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees: []
+---
+
+## Description
+
+<!-- Clear, concise description of the bug -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should happen -->
+
+## Actual behavior
+
+<!-- What actually happens -->
+
+## Environment
+
+- OS: <!-- e.g. Windows 11, macOS 14, Ubuntu 22.04 -->
+- App version: <!-- from About or package.json -->
+- Electron / Node (if relevant):
+
+## Screenshots / recordings
+
+<!-- If applicable -->
+
+## Additional context
+
+<!-- Logs, config, or other details -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+description: Suggest a new feature or improvement
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+assignees: []
+---
+
+## Summary
+
+<!-- 1–3 sentences describing the feature -->
+
+## Problem / motivation
+
+<!-- What problem does this solve? Who is it for? -->
+
+## Proposed solution
+
+<!-- How could this work? -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about -->
+
+## Additional context
+
+<!-- Mockups, examples, or references -->

--- a/src/lib/hooks/useHardwareAcceleration.ts
+++ b/src/lib/hooks/useHardwareAcceleration.ts
@@ -1,0 +1,35 @@
+import { createSignal, onMount } from "solid-js";
+
+/**
+ * Hook for hardware acceleration preference (saved to settings.json, applied on next launch).
+ * In Electron: syncs with main process via IPC. Outside Electron: local state only.
+ * Value is "enabled" (true = HA on, false = HA off).
+ */
+function useHardwareAcceleration() {
+  const [hardwareAcceleration, setHardwareAcceleration] = createSignal(true);
+
+  onMount(() => {
+    const api = typeof window !== "undefined" ? window.electron : undefined;
+    if (api) {
+      api
+        .getHardwareAccelerationDisabled()
+        .then((disabled: boolean) => setHardwareAcceleration(!disabled))
+        .catch(() => undefined);
+    }
+  });
+
+  const setEnabled = (enabled: boolean) => {
+    setHardwareAcceleration(enabled);
+    const api = typeof window !== "undefined" ? window.electron : undefined;
+    if (api) {
+      api.setHardwareAccelerationDisabled(!enabled).catch(() => undefined);
+    }
+  };
+
+  return {
+    hardwareAcceleration,
+    setHardwareAcceleration: setEnabled,
+  };
+}
+
+export default useHardwareAcceleration;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -18,11 +18,13 @@ import { Section, SelectField, Slider, Toggle } from "@components/ui";
 import { logger } from "@lib/logger";
 import { showToast } from "@stores/toast";
 import styles from "./Settings.module.css";
+import useHardwareAcceleration from "@lib/hooks/useHardwareAcceleration";
 
 export function Settings() {
   const [t, locale, setLocale] = useI18n();
   const [inputDevices, setInputDevices] = createSignal<AudioDevice[]>([]);
   const [outputDevices, setOutputDevices] = createSignal<AudioDevice[]>([]);
+  const { hardwareAcceleration, setHardwareAcceleration } = useHardwareAcceleration();
 
   onMount(async () => {
     try {
@@ -145,6 +147,26 @@ export function Settings() {
               description={t("settings.echoCancellationDesc")}
               checked={audioStore.echoCancellationEnabled()}
               onChange={(e) => audioStore.setEchoCancellationEnabled(e.currentTarget.checked)}
+            />
+          </div>
+        </Section>
+
+        <Section title="Hardware Acceleration">
+          <div class={styles.toggleList}>
+            <Toggle
+              label="Hardware Acceleration"
+              description="Enable hardware acceleration for better performance. Restart the app to apply."
+              checked={hardwareAcceleration()}
+              onChange={(e) => {
+                const enabled = e.currentTarget.checked;
+                setHardwareAcceleration(enabled);
+                if (typeof window !== "undefined" && window.electron) {
+                  showToast({
+                    type: "info",
+                    message: "Restart the app for the change to take effect.",
+                  });
+                }
+              }}
             />
           </div>
         </Section>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,10 +4,13 @@
  * Runs before the renderer loads, with access to Node.js APIs.
  * Use contextBridge to safely expose APIs to the renderer.
  *
- * Currently empty - add IPC handlers here when needed for:
- * - File system access
- * - Native OS features
- * - Secure communication between main and renderer
- *
  * @see https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
  */
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("electron", {
+  getHardwareAccelerationDisabled: () =>
+    ipcRenderer.invoke("settings:getHardwareAccelerationDisabled"),
+  setHardwareAccelerationDisabled: (disabled: boolean) =>
+    ipcRenderer.invoke("settings:setHardwareAccelerationDisabled", disabled),
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -16,3 +16,17 @@ interface ImportMetaEnv {
   readonly PROD: boolean;
   readonly MODE: string;
 }
+
+/** Electron APIs exposed via preload (only in Electron app) */
+export interface ElectronAPI {
+  getHardwareAccelerationDisabled: () => Promise<boolean>;
+  setHardwareAccelerationDisabled: (disabled: boolean) => Promise<void>;
+}
+
+declare global {
+  interface Window {
+    electron?: ElectronAPI;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary

Makes hardware acceleration a user preference: load/save from `settings.json` in userData at startup, expose get/set via IPC and preload, and add a Settings toggle with a "restart to apply" flow. Fixes Windows 11 24H2/25H2 DWM compositor flicker when users leave the default (HA disabled on Windows).

## Changes

- **Main:** Read `settings.json` at startup; if `hardwareAcceleration.disabled` is true, call `app.disableHardwareAcceleration()`. Default: disabled on Windows (DWM flicker workaround), enabled on Linux/macOS. Added `writeSettings()` and IPC handlers `settings:getHardwareAccelerationDisabled` / `settings:setHardwareAccelerationDisabled`.
- **Preload:** Expose `getHardwareAccelerationDisabled()` and `setHardwareAccelerationDisabled(disabled)` via `contextBridge` on `window.electron`.
- **Hook:** `useHardwareAcceleration` syncs with main via IPC on mount and when the user toggles; falls back to local state when not in Electron.
- **Settings:** Toggle for "Hardware Acceleration" with description and toast "Restart the app for the change to take effect" when toggled in Electron.
- **Types:** `ElectronAPI` and `Window.electron` in `vite-env.d.ts`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Documentation (changes to docs only)
- [ ] Chore (dependency updates, config changes, etc.)

---

## Pre-Merge Checklist

### Code Quality

- [x] Code follows project style (ESLint passes)
- [x] TypeScript has no errors (`pnpm typecheck`)
- [x] No `console.log` statements left in code (use `logger` instead)
- [x] New code has appropriate comments/JSDoc

### Testing

- [x] Unit tests pass (`pnpm test`)
- [ ] New features have test coverage (hook is Electron-only; manual verification)
- [ ] E2E tests pass if applicable (`pnpm e2e`)

### Documentation

- [ ] README updated if needed
- [ ] TECHNICAL_ROADMAP.md updated if this completes a phase
- [x] JSDoc added for new public functions/components

### Manual Verification

- [ ] App starts without errors (`pnpm dev`)
- [ ] Settings → Hardware Acceleration toggle loads current value and persists on change
- [ ] After toggle + restart, HA state matches preference (e.g. on Windows default off = no flicker)
- [ ] Settings persist correctly (settings.json in userData)

---

## Screenshots/Recordings

N/A — Settings toggle and toast only.

## Testing Instructions

1. Run `pnpm dev` on Windows; confirm no flicker (default HA off).
2. Open Settings → toggle Hardware Acceleration on; see toast to restart.
3. Restart app; open Settings again — toggle should show on. Move mouse — if flicker returns, HA is on as expected.
4. Toggle off, restart; flicker should disappear again.
5. On Linux/macOS, default should be on; toggle and restart should persist.

## Related Issues

Fixes #38