### PR TITLE
chore(biome): import organizing + JS coverage + solid:all + strict warnings

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -34,8 +34,12 @@
       "bracketSpacing": true
     }
   },
-  // organizeImports would touch 85 files; enable later as its own commit if wanted
-  "assist": { "enabled": false },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": { "organizeImports": "on" }
+    }
+  },
   "linter": {
     "enabled": true,
     "domains": { "solid": "recommended" },

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -3,11 +3,12 @@
   "root": true,
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
-    // ts/tsx only — same scope as the old `eslint --ext .ts,.tsx` + prettier globs.
+    // ts/tsx/js (js added post-migration; covers the signaling server).
     // dist is negated explicitly because it is not in .gitignore (only in the clean script).
     "includes": [
       "**/*.ts",
       "**/*.tsx",
+      "**/*.js",
       "!**/node_modules",
       "!**/.vite",
       "!**/out",
@@ -42,7 +43,7 @@
   },
   "linter": {
     "enabled": true,
-    "domains": { "solid": "recommended" },
+    "domains": { "solid": "all" },
     "rules": { "preset": "recommended" }
   },
   "overrides": [

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -3,7 +3,7 @@
  *
  * Tests the core navigation flows through the sidebar.
  */
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("Navigation", () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -3,7 +3,7 @@
  *
  * Tests the audio settings configuration.
  */
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("Settings Page", () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/tent.spec.ts
+++ b/e2e/tent.spec.ts
@@ -4,7 +4,7 @@
  * Tests the spatial audio demo functionality.
  * The Tent is the home page at route "/"
  */
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("The Tent Page", () => {
   test.beforeEach(async ({ page }) => {

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -11,14 +11,15 @@
  *   pnpm package -> create distributable
  *   pnpm make    -> create installers
  */
-import type { ForgeConfig } from "@electron-forge/shared-types";
-import { MakerSquirrel } from "@electron-forge/maker-squirrel";
-import { MakerZIP } from "@electron-forge/maker-zip";
+
+import { FuseV1Options, FuseVersion } from "@electron/fuses";
 import { MakerDeb } from "@electron-forge/maker-deb";
 import { MakerRpm } from "@electron-forge/maker-rpm";
-import { VitePlugin } from "@electron-forge/plugin-vite";
+import { MakerSquirrel } from "@electron-forge/maker-squirrel";
+import { MakerZIP } from "@electron-forge/maker-zip";
 import { FusesPlugin } from "@electron-forge/plugin-fuses";
-import { FuseV1Options, FuseVersion } from "@electron/fuses";
+import { VitePlugin } from "@electron-forge/plugin-vite";
+import type { ForgeConfig } from "@electron-forge/shared-types";
 
 const config: ForgeConfig = {
   packagerConfig: {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "biome format --write .",
     "format:check": "biome format .",
     "typecheck": "tsc --noEmit",
-    "check": "pnpm typecheck && biome check . && pnpm test",
+    "check": "pnpm typecheck && biome check --error-on-warnings . && pnpm test",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/types/src/audio.ts
+++ b/packages/types/src/audio.ts
@@ -1,4 +1,4 @@
-import type { Position, Wall, Bounds } from "./geometry";
+import type { Bounds, Position, Wall } from "./geometry";
 
 // ============================================================================
 // Core Audio Types

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,45 +1,42 @@
-// Geometry types
-export type { Position, Wall, Bounds } from "./geometry";
-
-// WebRTC types
-export type { RemotePeerState, DataChannelMessage } from "./webRTC";
-
 // Audio types
 export type {
+  AcousticRoom,
+  AcousticWall,
+  AudioNodes,
+  AudioParameterOptions,
+  AudioParameters,
+  AudioSourceType,
   DirectivityPattern,
   DistanceModel,
-  WaveformType,
-  AudioSourceType,
+  DrawnRoom,
+  Listener,
+  Material,
+  Opening,
+  Room,
+  SoundSource,
+  SourceConfig,
+  SpatialParams,
   Speaker,
   SpeakerState,
-  SourceConfig,
-  SoundSource,
-  Listener,
-  Room,
-  Material,
-  AcousticWall,
-  Opening,
-  AcousticRoom,
-  DrawnRoom,
-  SpatialParams,
-  AudioParameters,
-  AudioParameterOptions,
-  AudioNodes,
+  WaveformType,
 } from "./audio";
-
+// Geometry types
+export type { Bounds, Position, Wall } from "./geometry";
 // UI types
 export type {
-  SelectOption,
-  Tab,
-  ListItem,
-  ToastType,
-  ToastData,
-  Toast,
-  ToastOptions,
-  ThemeMode,
-  ResolvedTheme,
+  AudioDevice,
   ButtonVariant,
   DrawingMode,
+  ListItem,
   NavItem,
-  AudioDevice,
+  ResolvedTheme,
+  SelectOption,
+  Tab,
+  ThemeMode,
+  Toast,
+  ToastData,
+  ToastOptions,
+  ToastType,
 } from "./ui";
+// WebRTC types
+export type { DataChannelMessage, RemotePeerState } from "./webRTC";

--- a/packages/ui/src/components/Button/Button.test.tsx
+++ b/packages/ui/src/components/Button/Button.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Button.test.tsx - Unit tests for Button component
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import { Button } from "./Button";
 
 describe("Button", () => {

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -10,8 +10,9 @@
  * <Button variant="success" icon="🔊" onClick={play}>Play</Button>
  * <Button icon="✕" aria-label="Close" onClick={close} />
  */
-import { type JSX, splitProps } from "solid-js";
+
 import type { ButtonVariant } from "@clippis/types";
+import { type JSX, splitProps } from "solid-js";
 import styles from "./Button.module.css";
 
 export type { ButtonVariant };

--- a/packages/ui/src/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/packages/ui/src/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,8 +1,9 @@
 /**
  * ErrorBoundary.test.tsx - Unit tests for ErrorBoundary component
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+
 import { render, screen } from "@solidjs/testing-library";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorBoundary } from "./ErrorBoundary";
 
 // Component that throws an error

--- a/packages/ui/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -9,7 +9,7 @@
  *   <SomeComponent />
  * </ErrorBoundary>
  */
-import { ErrorBoundary as SolidErrorBoundary, type JSX } from "solid-js";
+import { type JSX, ErrorBoundary as SolidErrorBoundary } from "solid-js";
 import { Button } from "../Button";
 import styles from "./ErrorBoundary.module.css";
 

--- a/packages/ui/src/components/FormField/FormField.tsx
+++ b/packages/ui/src/components/FormField/FormField.tsx
@@ -4,7 +4,7 @@
  * Provides consistent styling for form inputs across the app.
  * Includes label, input/select, and optional hint text.
  */
-import { type JSX, createUniqueId, splitProps, Show } from "solid-js";
+import { createUniqueId, type JSX, Show, splitProps } from "solid-js";
 import styles from "./FormField.module.css";
 
 /** Common props for all field types */

--- a/packages/ui/src/components/FormField/index.ts
+++ b/packages/ui/src/components/FormField/index.ts
@@ -1,1 +1,1 @@
-export { InputField, DropdownField, SliderField, FieldGroup, ButtonRow } from "./FormField";
+export { ButtonRow, DropdownField, FieldGroup, InputField, SliderField } from "./FormField";

--- a/packages/ui/src/components/ItemList/ItemList.tsx
+++ b/packages/ui/src/components/ItemList/ItemList.tsx
@@ -11,8 +11,9 @@
  *   onSelect={(id) => setSelectedId(id)}
  * />
  */
-import { For, Show, type JSX } from "solid-js";
+
 import type { ListItem } from "@clippis/types";
+import { For, type JSX, Show } from "solid-js";
 import styles from "./ItemList.module.css";
 
 /** @deprecated Use ListItem from @clippis/types instead */

--- a/packages/ui/src/components/Section/Section.test.tsx
+++ b/packages/ui/src/components/Section/Section.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Section.test.tsx - Unit tests for Section component
  */
-import { describe, it, expect } from "vitest";
+
 import { render, screen } from "@solidjs/testing-library";
+import { describe, expect, it } from "vitest";
 import { Section } from "./Section";
 
 describe("Section", () => {

--- a/packages/ui/src/components/SelectField/SelectField.test.tsx
+++ b/packages/ui/src/components/SelectField/SelectField.test.tsx
@@ -1,8 +1,9 @@
 /**
  * SelectField.test.tsx - Unit tests for SelectField component
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import { SelectField } from "./SelectField";
 
 describe("SelectField", () => {

--- a/packages/ui/src/components/SelectField/SelectField.tsx
+++ b/packages/ui/src/components/SelectField/SelectField.tsx
@@ -11,8 +11,9 @@
  *   placeholder="Select..."
  * />
  */
-import { type JSX, For, splitProps, createUniqueId } from "solid-js";
+
 import type { SelectOption } from "@clippis/types";
+import { createUniqueId, For, type JSX, splitProps } from "solid-js";
 import styles from "./SelectField.module.css";
 
 export type { SelectOption };

--- a/packages/ui/src/components/Slider/Slider.test.tsx
+++ b/packages/ui/src/components/Slider/Slider.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Slider.test.tsx - Unit tests for Slider component
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import { Slider } from "./Slider";
 
 describe("Slider", () => {

--- a/packages/ui/src/components/Slider/Slider.tsx
+++ b/packages/ui/src/components/Slider/Slider.tsx
@@ -9,7 +9,7 @@
  * @example
  * <Slider id="volume" label="Volume" min={0} max={1} step={0.01} value={0.5} showValue />
  */
-import { type JSX, splitProps, createUniqueId } from "solid-js";
+import { createUniqueId, type JSX, splitProps } from "solid-js";
 import styles from "./Slider.module.css";
 
 interface SliderProps extends Omit<JSX.InputHTMLAttributes<HTMLInputElement>, "type"> {

--- a/packages/ui/src/components/Speaker/Speaker.tsx
+++ b/packages/ui/src/components/Speaker/Speaker.tsx
@@ -10,8 +10,9 @@
  *
  * Used in FullDemo for both speakers and the listener.
  */
-import type { JSX } from "solid-js";
+
 import type { Position } from "@clippis/types";
+import type { JSX } from "solid-js";
 import styles from "./Speaker.module.css";
 
 export type { Position };

--- a/packages/ui/src/components/Speaker/index.ts
+++ b/packages/ui/src/components/Speaker/index.ts
@@ -1,4 +1,4 @@
 /**
  * Speaker component exports
  */
-export { Speaker, type SpeakerProps, type Position } from "./Speaker";
+export { type Position, Speaker, type SpeakerProps } from "./Speaker";

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Tabs.test.tsx - Unit tests for Tabs component
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import { Tabs } from "./Tabs";
 
 describe("Tabs", () => {

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -14,8 +14,9 @@
  *   ariaLabel="Demo options"
  * />
  */
-import { For, createSignal } from "solid-js";
+
 import type { Tab } from "@clippis/types";
+import { createSignal, For } from "solid-js";
 import styles from "./Tabs.module.css";
 
 export type { Tab };

--- a/packages/ui/src/components/Tabs/index.ts
+++ b/packages/ui/src/components/Tabs/index.ts
@@ -1,1 +1,1 @@
-export { Tabs, type Tab } from "./Tabs";
+export { type Tab, Tabs } from "./Tabs";

--- a/packages/ui/src/components/Toast/Toast.test.tsx
+++ b/packages/ui/src/components/Toast/Toast.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Toast.test.tsx - Unit tests for Toast component
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import { ToastContainer, type ToastData } from "./Toast";
 
 describe("ToastContainer", () => {

--- a/packages/ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/src/components/Toast/Toast.tsx
@@ -7,11 +7,12 @@
  * @example
  * <ToastContainer toasts={toasts()} onDismiss={dismissToast} />
  */
+
+import type { ToastData, ToastType } from "@clippis/types";
 import { For } from "solid-js";
-import type { ToastType, ToastData } from "@clippis/types";
 import styles from "./Toast.module.css";
 
-export type { ToastType, ToastData };
+export type { ToastData, ToastType };
 
 interface ToastContainerProps {
   /** Array of toast notifications to display */

--- a/packages/ui/src/components/Toggle/Toggle.test.tsx
+++ b/packages/ui/src/components/Toggle/Toggle.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Toggle.test.tsx - Unit tests for Toggle component
  */
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@solidjs/testing-library";
+
+import { fireEvent, render, screen } from "@solidjs/testing-library";
+import { describe, expect, it, vi } from "vitest";
 import { Toggle } from "./Toggle";
 
 describe("Toggle", () => {

--- a/packages/ui/src/components/Toggle/Toggle.tsx
+++ b/packages/ui/src/components/Toggle/Toggle.tsx
@@ -12,7 +12,7 @@
  *   onChange={handleChange}
  * />
  */
-import { type JSX, splitProps, createUniqueId } from "solid-js";
+import { createUniqueId, type JSX, splitProps } from "solid-js";
 import styles from "./Toggle.module.css";
 
 interface ToggleProps extends Omit<JSX.InputHTMLAttributes<HTMLInputElement>, "type"> {

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -4,13 +4,13 @@
 export { Button, type ButtonVariant } from "./Button";
 export { ColorSwatches, type ColorSwatchesProps } from "./ColorSwatches";
 export { ErrorBoundary } from "./ErrorBoundary";
-export { InputField, DropdownField, SliderField, FieldGroup, ButtonRow } from "./FormField";
+export { ButtonRow, DropdownField, FieldGroup, InputField, SliderField } from "./FormField";
 export { ItemList, type ItemListItem, type ItemListProps } from "./ItemList";
 export { Panel, type PanelProps } from "./Panel";
 export { Section } from "./Section";
 export { SelectField, type SelectOption } from "./SelectField";
 export { Slider } from "./Slider";
-export { Speaker, type SpeakerProps, type Position as SpeakerPosition } from "./Speaker";
-export { Tabs, type Tab } from "./Tabs";
+export { type Position as SpeakerPosition, Speaker, type SpeakerProps } from "./Speaker";
+export { type Tab, Tabs } from "./Tabs";
 export { ToastContainer, type ToastData, type ToastType } from "./Toast";
 export { Toggle } from "./Toggle";

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -5,9 +5,10 @@
  * Note: Tests are typically run from the root monorepo for better deduplication.
  * This config is for standalone package testing.
  */
-import { defineConfig } from "vitest/config";
-import solid from "vite-plugin-solid";
+
 import path from "node:path";
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [

--- a/src/components/audio/FullDemo/FullDemo.tsx
+++ b/src/components/audio/FullDemo/FullDemo.tsx
@@ -13,8 +13,8 @@
  * and wraps them with the DemoProvider context.
  */
 import { audioStore } from "@stores/audio";
+import { Sidebar, SpatialCanvas, StatusBar, Toolbar } from "./components";
 import { DemoProvider, useDemoContext } from "./context";
-import { Toolbar, SpatialCanvas, StatusBar, Sidebar } from "./components";
 import styles from "./FullDemo.module.css";
 
 /** Audio banner shown when audio is not yet initialized */

--- a/src/components/audio/FullDemo/components/Sidebar/Sidebar.tsx
+++ b/src/components/audio/FullDemo/components/Sidebar/Sidebar.tsx
@@ -4,11 +4,11 @@
  * Composes all panel components in the correct order.
  */
 import {
-  SpeakerPropertiesPanel,
-  RoomPropertiesPanel,
   AudioSettingsPanel,
-  SpeakersListPanel,
+  RoomPropertiesPanel,
   RoomsListPanel,
+  SpeakerPropertiesPanel,
+  SpeakersListPanel,
 } from "../panels";
 import styles from "./Sidebar.module.css";
 

--- a/src/components/audio/FullDemo/components/SpatialCanvas/RoomRenderer.tsx
+++ b/src/components/audio/FullDemo/components/SpatialCanvas/RoomRenderer.tsx
@@ -4,7 +4,7 @@
  * Displays room areas with labels and colored walls on the canvas.
  */
 import { For } from "solid-js";
-import type { DrawnRoom, DrawingMode } from "../../context/types";
+import type { DrawingMode, DrawnRoom } from "../../context/types";
 import { toPercent } from "../../utils";
 import styles from "./SpatialCanvas.module.css";
 

--- a/src/components/audio/FullDemo/components/SpatialCanvas/SoundPaths.tsx
+++ b/src/components/audio/FullDemo/components/SpatialCanvas/SoundPaths.tsx
@@ -5,7 +5,7 @@
  * with dashed lines when the path is blocked by walls.
  */
 import { For } from "solid-js";
-import type { SpeakerState, Position } from "../../context/types";
+import type { Position, SpeakerState } from "../../context/types";
 import { toPercent } from "../../utils";
 import styles from "./SpatialCanvas.module.css";
 

--- a/src/components/audio/FullDemo/components/SpatialCanvas/SpatialCanvas.tsx
+++ b/src/components/audio/FullDemo/components/SpatialCanvas/SpatialCanvas.tsx
@@ -6,13 +6,14 @@
  * - Position and rotate speakers (all entities are speakers)
  * - Switch perspective (who you are)
  */
-import { Show, For } from "solid-js";
-import { Speaker } from "@components/ui";
-import { useDemoContext } from "@components/audio/FullDemo/context";
-import { toPercent } from "@components/audio/FullDemo/utils";
+
 import { DrawingPreview } from "@components/audio/FullDemo/components/SpatialCanvas/DrawingPreview";
 import { RoomRenderer } from "@components/audio/FullDemo/components/SpatialCanvas/RoomRenderer";
 import { SoundPaths } from "@components/audio/FullDemo/components/SpatialCanvas/SoundPaths";
+import { useDemoContext } from "@components/audio/FullDemo/context";
+import { toPercent } from "@components/audio/FullDemo/utils";
+import { Speaker } from "@components/ui";
+import { For, Show } from "solid-js";
 import styles from "./SpatialCanvas.module.css";
 
 export function SpatialCanvas() {

--- a/src/components/audio/FullDemo/components/SpatialCanvas/index.ts
+++ b/src/components/audio/FullDemo/components/SpatialCanvas/index.ts
@@ -1,4 +1,4 @@
-export { SpatialCanvas } from "./SpatialCanvas";
 export { DrawingPreview } from "./DrawingPreview";
 export { RoomRenderer } from "./RoomRenderer";
 export { SoundPaths } from "./SoundPaths";
+export { SpatialCanvas } from "./SpatialCanvas";

--- a/src/components/audio/FullDemo/components/Toolbar/Toolbar.tsx
+++ b/src/components/audio/FullDemo/components/Toolbar/Toolbar.tsx
@@ -4,9 +4,10 @@
  * Contains mode selection, add speaker, volume, and reset button.
  * Play controls are in the SpeakerPropertiesPanel for per-speaker control.
  */
+
+import { useDemoContext } from "@components/audio/FullDemo/context";
 import { Button, Slider } from "@components/ui";
 import { audioStore } from "@stores/audio";
-import { useDemoContext } from "@components/audio/FullDemo/context";
 import styles from "./Toolbar.module.css";
 
 export function Toolbar() {

--- a/src/components/audio/FullDemo/components/index.ts
+++ b/src/components/audio/FullDemo/components/index.ts
@@ -1,8 +1,9 @@
 /**
  * components/index.ts - Barrel export for all demo components
  */
-export { Toolbar } from "./Toolbar";
+
+export * from "./panels";
+export { Sidebar } from "./Sidebar";
 export { SpatialCanvas } from "./SpatialCanvas";
 export { StatusBar } from "./StatusBar";
-export { Sidebar } from "./Sidebar";
-export * from "./panels";
+export { Toolbar } from "./Toolbar";

--- a/src/components/audio/FullDemo/components/panels/AudioSettingsPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/AudioSettingsPanel.tsx
@@ -3,11 +3,12 @@
  *
  * Contains perspective selection, distance model, max distance, rear gain, and visual settings.
  */
-import { For, Index } from "solid-js";
+
 import type { DistanceModel } from "@clippis/types";
-import { Panel, Toggle, DropdownField, SliderField, FieldGroup } from "@components/ui";
-import { useDemoContext } from "@components/audio/FullDemo/context";
 import { DISTANCE_MODEL_OPTIONS } from "@components/audio/FullDemo/constants";
+import { useDemoContext } from "@components/audio/FullDemo/context";
+import { DropdownField, FieldGroup, Panel, SliderField, Toggle } from "@components/ui";
+import { For, Index } from "solid-js";
 
 export function AudioSettingsPanel() {
   const {

--- a/src/components/audio/FullDemo/components/panels/RoomPropertiesPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/RoomPropertiesPanel.tsx
@@ -3,18 +3,19 @@
  *
  * Allows changing room name, color, and wall attenuation.
  */
-import { Show, createEffect, createSignal } from "solid-js";
+
+import { ROOM_COLORS } from "@components/audio/FullDemo/constants";
+import { useDemoContext } from "@components/audio/FullDemo/context";
 import {
   Button,
-  ColorSwatches,
-  Panel,
-  InputField,
-  SliderField,
-  FieldGroup,
   ButtonRow,
+  ColorSwatches,
+  FieldGroup,
+  InputField,
+  Panel,
+  SliderField,
 } from "@components/ui";
-import { useDemoContext } from "@components/audio/FullDemo/context";
-import { ROOM_COLORS } from "@components/audio/FullDemo/constants";
+import { createEffect, createSignal, Show } from "solid-js";
 
 export function RoomPropertiesPanel() {
   const {

--- a/src/components/audio/FullDemo/components/panels/RoomsListPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/RoomsListPanel.tsx
@@ -3,8 +3,9 @@
  *
  * Shows each room with its name and color.
  */
-import { Panel, ItemList } from "@components/ui";
+
 import { useDemoContext } from "@components/audio/FullDemo/context";
+import { ItemList, Panel } from "@components/ui";
 
 export function RoomsListPanel() {
   const { rooms, selectedRoomId, setSelectedRoomId } = useDemoContext();

--- a/src/components/audio/FullDemo/components/panels/SpeakerPropertiesPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/SpeakerPropertiesPanel.tsx
@@ -3,21 +3,22 @@
  *
  * Allows changing source type (oscillator/microphone), directivity pattern, frequency, and color.
  */
-import { Show, For } from "solid-js";
-import { SPEAKER_COLORS } from "@lib/spatial-audio";
-import type { DirectivityPattern, AudioSourceType } from "@clippis/types";
+
+import type { AudioSourceType, DirectivityPattern } from "@clippis/types";
+import { DIRECTIVITY_OPTIONS, SOURCE_TYPE_OPTIONS } from "@components/audio/FullDemo/constants";
+import { useDemoContext } from "@components/audio/FullDemo/context";
+import { getNoteName } from "@components/audio/FullDemo/utils";
 import {
   Button,
-  ColorSwatches,
-  Panel,
-  DropdownField,
-  SliderField,
-  FieldGroup,
   ButtonRow,
+  ColorSwatches,
+  DropdownField,
+  FieldGroup,
+  Panel,
+  SliderField,
 } from "@components/ui";
-import { useDemoContext } from "@components/audio/FullDemo/context";
-import { DIRECTIVITY_OPTIONS, SOURCE_TYPE_OPTIONS } from "@components/audio/FullDemo/constants";
-import { getNoteName } from "@components/audio/FullDemo/utils";
+import { SPEAKER_COLORS } from "@lib/spatial-audio";
+import { For, Show } from "solid-js";
 
 export function SpeakerPropertiesPanel() {
   const {

--- a/src/components/audio/FullDemo/components/panels/SpeakersListPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/SpeakersListPanel.tsx
@@ -3,9 +3,10 @@
  *
  * Shows each speaker with its note/frequency and playing status.
  */
-import { Panel, ItemList } from "@components/ui";
+
 import { useDemoContext } from "@components/audio/FullDemo/context";
 import { getNoteName } from "@components/audio/FullDemo/utils";
+import { ItemList, Panel } from "@components/ui";
 
 export function SpeakersListPanel() {
   const { speakers, selectedSpeaker, setSelectedSpeaker, isPlaying } = useDemoContext();

--- a/src/components/audio/FullDemo/components/panels/index.ts
+++ b/src/components/audio/FullDemo/components/panels/index.ts
@@ -1,6 +1,6 @@
-export { SpeakerPropertiesPanel } from "./SpeakerPropertiesPanel";
-export { RoomPropertiesPanel } from "./RoomPropertiesPanel";
 export { AudioSettingsPanel } from "./AudioSettingsPanel";
-export { SpeakersListPanel } from "./SpeakersListPanel";
+export { RoomPropertiesPanel } from "./RoomPropertiesPanel";
 export { RoomsListPanel } from "./RoomsListPanel";
+export { SpeakerPropertiesPanel } from "./SpeakerPropertiesPanel";
+export { SpeakersListPanel } from "./SpeakersListPanel";
 export { WebRTCPanel } from "./WebRTCPanel";

--- a/src/components/audio/FullDemo/context/DemoContext.tsx
+++ b/src/components/audio/FullDemo/context/DemoContext.tsx
@@ -4,38 +4,39 @@
  * Provides shared state and actions for all demo components.
  * Composes specialized hooks for room, speaker, audio, and interaction management.
  */
-import {
-  createContext,
-  useContext,
-  createSignal,
-  createEffect,
-  onCleanup,
-  untrack,
-  type JSX,
-} from "solid-js";
+
 import type { DistanceModel } from "@clippis/types";
-import { calculateAudioParameters, createListener } from "@lib/spatial-audio-engine";
-import { audioStore } from "@stores/audio";
 import {
-  useMicrophone,
   useAudioPlayback,
+  useCanvasDrawing,
+  useMicrophone,
+  useRemoteSpeaker,
   useRoomManager,
   useSpeakerManager,
-  useCanvasDrawing,
-  useRemoteSpeaker,
 } from "@lib/hooks";
+import { logger } from "@lib/logger";
+import { calculateAudioParameters, createListener } from "@lib/spatial-audio-engine";
+import { isSpeakerInsideRoom } from "@lib/spatial-utils";
+import { audioStore } from "@stores/audio";
+import { showToast } from "@stores/toast";
 import { webRTCStore } from "@stores/webRTC";
-import type { SpeakerState, Position, AudioSourceType, DemoContextValue } from "./types";
 import {
-  ROOM_COLORS,
+  createContext,
+  createEffect,
+  createSignal,
+  type JSX,
+  onCleanup,
+  untrack,
+  useContext,
+} from "solid-js";
+import {
   DEFAULT_MAX_DISTANCE,
   DEFAULT_REAR_GAIN,
   DEFAULT_SPEAKERS,
+  ROOM_COLORS,
 } from "../constants";
-import { getPositionFromEvent, getScreenPosition, DEFAULT_ATTENUATION } from "../utils";
-import { showToast } from "@stores/toast";
-import { logger } from "@lib/logger";
-import { isSpeakerInsideRoom } from "@lib/spatial-utils";
+import { DEFAULT_ATTENUATION, getPositionFromEvent, getScreenPosition } from "../utils";
+import type { AudioSourceType, DemoContextValue, Position, SpeakerState } from "./types";
 
 // ============================================================================
 // SolidJS Context Value

--- a/src/components/audio/FullDemo/context/index.ts
+++ b/src/components/audio/FullDemo/context/index.ts
@@ -1,5 +1,6 @@
 /**
  * context/index.ts - Barrel export for demo context
  */
-export * from "./types";
+
 export { DemoProvider, useDemoContext } from "./DemoContext";
+export * from "./types";

--- a/src/components/audio/FullDemo/context/types.ts
+++ b/src/components/audio/FullDemo/context/types.ts
@@ -6,22 +6,23 @@
  *
  * We do this because if we have to change from @clippis/types to a different package, we only have to change it in one place.
  */
-import type { CalculateAudioParameters } from "@lib/spatial-audio-engine";
+
 import type {
-  AudioSourceType,
+  AudioNodes,
   AudioParameters,
+  AudioSourceType,
+  Bounds,
   DirectivityPattern,
   DistanceModel,
   DrawingMode,
   DrawnRoom,
   Position,
   RemotePeerState,
+  SelectOption,
   SpeakerState,
   Wall,
-  Bounds,
-  AudioNodes,
-  SelectOption,
 } from "@clippis/types";
+import type { CalculateAudioParameters } from "@lib/spatial-audio-engine";
 import type { Accessor, Setter } from "solid-js";
 
 /** Context value type - exposes all state and actions to components */
@@ -141,20 +142,20 @@ interface DemoContextValue {
 }
 
 export type {
-  // Geometry
-  Position,
-  Wall,
+  AudioNodes,
+  AudioSourceType,
   Bounds,
+  // Component
+  DemoContextValue,
   // Audio
   DirectivityPattern,
   DistanceModel,
-  AudioSourceType,
-  SpeakerState,
-  DrawnRoom,
-  AudioNodes,
   // UI
   DrawingMode,
+  DrawnRoom,
+  // Geometry
+  Position,
   SelectOption,
-  // Component
-  DemoContextValue,
+  SpeakerState,
+  Wall,
 };

--- a/src/components/audio/FullDemo/index.ts
+++ b/src/components/audio/FullDemo/index.ts
@@ -1,17 +1,16 @@
 /**
  * FullDemo/index.ts - Barrel export for the FullDemo component
  */
-export { FullDemo } from "./FullDemo";
 
 // Re-export context for external use if needed
 export { DemoProvider, useDemoContext } from "./context";
-
 // Re-export types for external use
 export type {
-  SpeakerState,
   AudioNodes,
-  DrawnRoom,
   DrawingMode,
+  DrawnRoom,
   Position,
+  SpeakerState,
   Wall,
 } from "./context/types";
+export { FullDemo } from "./FullDemo";

--- a/src/components/audio/FullDemo/utils.ts
+++ b/src/components/audio/FullDemo/utils.ts
@@ -7,10 +7,10 @@
 
 // Re-export only what's actually used by demo components
 export {
-  toPercent,
+  DEFAULT_ATTENUATION,
   getPositionFromEvent,
   getScreenPosition,
-  DEFAULT_ATTENUATION,
+  toPercent,
 } from "@lib/spatial-utils";
 
 import { FREQUENCY_NOTES } from "./constants";

--- a/src/components/layout/App.tsx
+++ b/src/components/layout/App.tsx
@@ -10,8 +10,8 @@
  * Used as the `root` prop for the SolidJS Router.
  */
 import type { JSX } from "solid-js";
-import { Sidebar } from "./Sidebar";
 import styles from "./App.module.css";
+import { Sidebar } from "./Sidebar";
 
 interface AppProps {
   /** Page content rendered by the router (optional during route transitions) */

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,9 +11,10 @@
  *   /         -> The Tent (spatial audio demo)
  *   /settings -> Settings page
  */
+
+import { useI18n } from "@lib/i18n";
 import { A, useLocation } from "@solidjs/router";
 import { audioStore } from "@stores/audio";
-import { useI18n } from "@lib/i18n";
 import styles from "./Sidebar.module.css";
 
 interface NavItem {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -15,6 +15,7 @@
 import { useI18n } from "@lib/i18n";
 import { A, useLocation } from "@solidjs/router";
 import { audioStore } from "@stores/audio";
+import { For } from "solid-js";
 import styles from "./Sidebar.module.css";
 
 interface NavItem {
@@ -45,18 +46,20 @@ export function Sidebar() {
       </div>
 
       <nav class={styles.nav} aria-label="Main navigation">
-        {navItems.map((item) => (
-          <A
-            href={item.path}
-            class={`${styles.navItem} ${isActive(item.path) ? styles.active : ""}`}
-            aria-current={isActive(item.path) ? "page" : undefined}
-          >
-            <span class={styles.navIcon} aria-hidden="true">
-              {item.icon}
-            </span>
-            <span>{t(item.labelKey)}</span>
-          </A>
-        ))}
+        <For each={navItems}>
+          {(item) => (
+            <A
+              href={item.path}
+              class={`${styles.navItem} ${isActive(item.path) ? styles.active : ""}`}
+              aria-current={isActive(item.path) ? "page" : undefined}
+            >
+              <span class={styles.navIcon} aria-hidden="true">
+                {item.icon}
+              </span>
+              <span>{t(item.labelKey)}</span>
+            </A>
+          )}
+        </For>
       </nav>
 
       <div class={styles.footer}>

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -3,9 +3,10 @@
  *
  * Wraps the @clippis/ui ErrorBoundary with app-specific error logging.
  */
-import type { JSX } from "solid-js";
+
 import { ErrorBoundary as UIErrorBoundary } from "@clippis/ui";
 import { logger } from "@lib/logger";
+import type { JSX } from "solid-js";
 
 interface ErrorBoundaryProps {
   /** Child components to wrap */

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -5,7 +5,7 @@
  * Re-exports everything from the UI library for convenience.
  */
 import { ToastContainer as UIToastContainer } from "@clippis/ui";
-import { toasts, dismissToast } from "@stores/toast";
+import { dismissToast, toasts } from "@stores/toast";
 
 // Re-export the type from the UI library
 export type { ToastData, ToastType } from "@clippis/ui";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -11,12 +11,12 @@
 // Pure UI components from @clippis/ui
 export {
   Button,
+  ButtonRow,
   type ButtonVariant,
   ColorSwatches,
   type ColorSwatchesProps,
   DropdownField,
   FieldGroup,
-  ButtonRow,
   InputField,
   ItemList,
   type ItemListItem,
@@ -29,10 +29,10 @@ export {
   Slider,
   SliderField,
   Speaker,
-  type SpeakerProps,
   type SpeakerPosition,
-  Tabs,
+  type SpeakerProps,
   type Tab,
+  Tabs,
   Toggle,
 } from "@clippis/ui";
 

--- a/src/lib/hooks/index.ts
+++ b/src/lib/hooks/index.ts
@@ -10,36 +10,34 @@
  * - Canvas drawing (useCanvasDrawing)
  */
 
-// Interaction hooks
-export { useDragHandler, useRotationHandler } from "@lib/hooks/useDragHandler";
-
 // Audio hooks
 export {
-  useAudioPlayback,
   type AudioNodes,
-  type PlaybackParams,
   type AudioPlaybackState,
+  type PlaybackParams,
+  useAudioPlayback,
 } from "@lib/hooks/useAudioPlayback";
 export {
-  useMicrophone,
-  type MicrophoneOptions,
-  type MicrophoneState,
-} from "@lib/hooks/useMicrophone";
-
-// State management hooks
-export { useRoomManager, type RoomConfig, type RoomManagerState } from "@lib/hooks/useRoomManager";
-export {
-  useSpeakerManager,
-  type SpeakerManagerOptions,
-  type SpeakerManagerState,
-} from "@lib/hooks/useSpeakerManager";
-export {
-  useRemoteSpeaker,
-  type UseRemoteSpeakerReturn,
-  type RemoteSpeakerOptions,
-} from "@lib/hooks/useRemoteSpeaker";
-export {
-  useCanvasDrawing,
   type CanvasDrawingOptions,
   type CanvasDrawingState,
+  useCanvasDrawing,
 } from "@lib/hooks/useCanvasDrawing";
+// Interaction hooks
+export { useDragHandler, useRotationHandler } from "@lib/hooks/useDragHandler";
+export {
+  type MicrophoneOptions,
+  type MicrophoneState,
+  useMicrophone,
+} from "@lib/hooks/useMicrophone";
+export {
+  type RemoteSpeakerOptions,
+  type UseRemoteSpeakerReturn,
+  useRemoteSpeaker,
+} from "@lib/hooks/useRemoteSpeaker";
+// State management hooks
+export { type RoomConfig, type RoomManagerState, useRoomManager } from "@lib/hooks/useRoomManager";
+export {
+  type SpeakerManagerOptions,
+  type SpeakerManagerState,
+  useSpeakerManager,
+} from "@lib/hooks/useSpeakerManager";

--- a/src/lib/hooks/useAudioPlayback.test.ts
+++ b/src/lib/hooks/useAudioPlayback.test.ts
@@ -1,9 +1,10 @@
 /**
  * useAudioPlayback.test.ts - Unit tests for audio playback hook
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { type AudioPlaybackState, useAudioPlayback } from "@lib/hooks/useAudioPlayback";
 import { createRoot } from "solid-js";
-import { useAudioPlayback, type AudioPlaybackState } from "@lib/hooks/useAudioPlayback";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock audio context and nodes
 const mockGainNode = {

--- a/src/lib/hooks/useAudioPlayback.ts
+++ b/src/lib/hooks/useAudioPlayback.ts
@@ -3,9 +3,10 @@
  *
  * Manages audio nodes for multiple speakers with real-time parameter updates.
  */
-import { createSignal, onCleanup, type Accessor } from "solid-js";
+
+import type { AudioNodes, AudioSourceType } from "@clippis/types";
 import { audioStore } from "@stores/audio";
-import type { AudioSourceType, AudioNodes } from "@clippis/types";
+import { type Accessor, createSignal, onCleanup } from "solid-js";
 
 export type { AudioNodes };
 

--- a/src/lib/hooks/useCanvasDrawing.test.ts
+++ b/src/lib/hooks/useCanvasDrawing.test.ts
@@ -1,9 +1,10 @@
 /**
  * useCanvasDrawing.test.ts - Unit tests for canvas drawing hook
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { type CanvasDrawingState, useCanvasDrawing } from "@lib/hooks/useCanvasDrawing";
 import { createRoot } from "solid-js";
-import { useCanvasDrawing, type CanvasDrawingState } from "@lib/hooks/useCanvasDrawing";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("useCanvasDrawing", () => {
   let drawing: CanvasDrawingState;

--- a/src/lib/hooks/useCanvasDrawing.ts
+++ b/src/lib/hooks/useCanvasDrawing.ts
@@ -3,8 +3,9 @@
  *
  * Handles draw mode mouse events for creating rectangular regions.
  */
-import { createSignal, type Accessor, type Setter } from "solid-js";
-import type { Position, DrawingMode } from "@clippis/types";
+
+import type { DrawingMode, Position } from "@clippis/types";
+import { type Accessor, createSignal, type Setter } from "solid-js";
 
 /** Options for canvas drawing */
 export interface CanvasDrawingOptions {

--- a/src/lib/hooks/useMicrophone.test.ts
+++ b/src/lib/hooks/useMicrophone.test.ts
@@ -1,9 +1,10 @@
 /**
  * useMicrophone.test.ts - Unit tests for microphone access hook
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { type MicrophoneState, useMicrophone } from "@lib/hooks/useMicrophone";
 import { createRoot } from "solid-js";
-import { useMicrophone, type MicrophoneState } from "@lib/hooks/useMicrophone";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Note: logger is mocked globally in src/test/setup.ts
 

--- a/src/lib/hooks/useMicrophone.ts
+++ b/src/lib/hooks/useMicrophone.ts
@@ -3,10 +3,11 @@
  *
  * Provides microphone stream management with proper cleanup.
  */
-import { createSignal, onCleanup, type Accessor } from "solid-js";
-import { showToast } from "@stores/toast";
-import { audioStore } from "@stores/audio";
+
 import { logger } from "@lib/logger";
+import { audioStore } from "@stores/audio";
+import { showToast } from "@stores/toast";
+import { type Accessor, createSignal, onCleanup } from "solid-js";
 
 export interface MicrophoneOptions {
   /** Called when microphone access is granted */

--- a/src/lib/hooks/useRemoteSpeaker.test.ts
+++ b/src/lib/hooks/useRemoteSpeaker.test.ts
@@ -8,9 +8,10 @@
  * - Audio parameter calculations
  * - Cleanup
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { type UseRemoteSpeakerReturn, useRemoteSpeaker } from "@lib/hooks/useRemoteSpeaker";
 import { createRoot } from "solid-js";
-import { useRemoteSpeaker, type UseRemoteSpeakerReturn } from "@lib/hooks/useRemoteSpeaker";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Note: logger is mocked globally in src/test/setup.ts
 

--- a/src/lib/hooks/useRemoteSpeaker.ts
+++ b/src/lib/hooks/useRemoteSpeaker.ts
@@ -5,17 +5,18 @@
  * (source → panner → gain → destination) and recomputes pan/gain whenever the
  * remote position, the listener, walls, or audio settings change.
  */
-import { createSignal, createMemo, createEffect, onCleanup, type Accessor } from "solid-js";
+
 import type {
-  Position,
-  AudioParameters,
   AudioParameterOptions,
+  AudioParameters,
   Listener,
+  Position,
   Wall,
 } from "@clippis/types";
+import { logger } from "@lib/logger";
 import { calculateAudioParameters } from "@lib/spatial-audio-engine";
 import { audioStore } from "@stores/audio";
-import { logger } from "@lib/logger";
+import { type Accessor, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 export interface RemoteSpeakerOptions {
   /** Listener (perspective) to spatialize against. Defaults to origin, facing up. */

--- a/src/lib/hooks/useRoomManager.test.ts
+++ b/src/lib/hooks/useRoomManager.test.ts
@@ -1,9 +1,10 @@
 /**
  * useRoomManager.test.ts - Unit tests for room management hook
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { type RoomManagerState, useRoomManager } from "@lib/hooks/useRoomManager";
 import { createRoot } from "solid-js";
-import { useRoomManager, type RoomManagerState } from "@lib/hooks/useRoomManager";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 describe("useRoomManager", () => {
   let manager: RoomManagerState;

--- a/src/lib/hooks/useRoomManager.ts
+++ b/src/lib/hooks/useRoomManager.ts
@@ -3,14 +3,15 @@
  *
  * Provides room CRUD operations and selection state.
  */
-import { createSignal, type Accessor, type Setter } from "solid-js";
+
 import type { DrawnRoom, Position, Wall } from "@clippis/types";
 import {
   createRoomFromCorners,
+  DEFAULT_ATTENUATION,
   isValidRoomSize,
   updateItemById,
-  DEFAULT_ATTENUATION,
 } from "@lib/spatial-utils";
+import { type Accessor, createSignal, type Setter } from "solid-js";
 
 /** Room creation configuration */
 export interface RoomConfig {

--- a/src/lib/hooks/useSpeakerManager.test.ts
+++ b/src/lib/hooks/useSpeakerManager.test.ts
@@ -1,10 +1,11 @@
 /**
  * useSpeakerManager.test.ts - Unit tests for speaker management hook
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createRoot } from "solid-js";
-import { useSpeakerManager, type SpeakerManagerState } from "@lib/hooks/useSpeakerManager";
+
 import type { SpeakerState } from "@clippis/types";
+import { type SpeakerManagerState, useSpeakerManager } from "@lib/hooks/useSpeakerManager";
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock SPEAKER_COLORS (must match exact import path in source)
 vi.mock("@lib/spatial-audio", () => ({

--- a/src/lib/hooks/useSpeakerManager.ts
+++ b/src/lib/hooks/useSpeakerManager.ts
@@ -3,10 +3,11 @@
  *
  * Provides speaker CRUD operations, selection, and perspective management.
  */
-import { createSignal, type Accessor, type Setter } from "solid-js";
-import type { SpeakerState, DirectivityPattern, AudioSourceType, Position } from "@clippis/types";
+
+import type { AudioSourceType, DirectivityPattern, Position, SpeakerState } from "@clippis/types";
 import { SPEAKER_COLORS } from "@lib/spatial-audio";
 import { generateId, updateItemById } from "@lib/spatial-utils";
+import { type Accessor, createSignal, type Setter } from "solid-js";
 
 /** Options for speaker manager initialization */
 export interface SpeakerManagerOptions {

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -13,11 +13,11 @@
  *   const [t] = useI18n();
  *   t("nav.settings")
  */
-import { createSignal, createContext, useContext, type JSX } from "solid-js";
-import * as i18n from "@solid-primitives/i18n";
 
 // Import translation files
 import en from "@locales/en.json";
+import * as i18n from "@solid-primitives/i18n";
+import { createContext, createSignal, type JSX, useContext } from "solid-js";
 
 // Available dictionaries
 const dictionaries = { en } as const;

--- a/src/lib/spatial-audio-engine.test.ts
+++ b/src/lib/spatial-audio-engine.test.ts
@@ -1,16 +1,17 @@
 /**
  * spatial-audio-engine.test.ts - Tests for advanced spatial audio engine
  */
-import { describe, it, expect } from "vitest";
+
 import {
+  calculateAudioParameters,
   calculateDirectivityGain,
   calculateDistanceAttenuation,
-  calculateStereoPan,
   calculateListenerDirectionalGain,
-  calculateAudioParameters,
-  createSourceConfig,
+  calculateStereoPan,
   createListener,
+  createSourceConfig,
 } from "@lib/spatial-audio-engine";
+import { describe, expect, it } from "vitest";
 
 describe("Directivity Patterns", () => {
   describe("omnidirectional", () => {

--- a/src/lib/spatial-audio-engine.ts
+++ b/src/lib/spatial-audio-engine.ts
@@ -13,22 +13,22 @@
  */
 
 import type {
-  Position,
-  Wall,
-  Listener,
+  AudioParameterOptions,
+  AudioParameters,
   DirectivityPattern,
   DistanceModel,
+  Listener,
+  Position,
   SourceConfig,
-  AudioParameters,
-  AudioParameterOptions,
+  Wall,
 } from "@clippis/types";
 
 import {
-  calculateDistance,
   calculateAngleToPoint,
-  normalizeAngle,
-  countWallsBetween,
+  calculateDistance,
   calculateWallAttenuation,
+  countWallsBetween,
+  normalizeAngle,
 } from "@lib/spatial-audio";
 
 // ============================================================================

--- a/src/lib/spatial-audio.test.ts
+++ b/src/lib/spatial-audio.test.ts
@@ -11,27 +11,28 @@
  *
  * Run with: pnpm test
  */
-import { describe, it, expect } from "vitest";
+
 import {
+  CARDINAL_DIRECTIONS,
+  calculateAngleToPoint,
+  calculateDirectionalGain,
   calculateDistance,
-  calculateVolume,
   calculatePan,
   calculateSpatialParams,
-  randomPosition,
-  randomFrequency,
-  createSoundSource,
-  calculateAngleToPoint,
-  normalizeAngle,
-  calculateDirectionalGain,
-  lineIntersectsWall,
-  countWallsBetween,
+  calculateVolume,
   calculateWallAttenuation,
+  countWallsBetween,
   createRectangularRoom,
+  createSoundSource,
   createSpeaker,
+  lineIntersectsWall,
+  normalizeAngle,
+  randomFrequency,
+  randomPosition,
   SOUND_FREQUENCIES,
-  CARDINAL_DIRECTIONS,
   SPEAKER_COLORS,
 } from "@lib/spatial-audio";
+import { describe, expect, it } from "vitest";
 
 describe("spatial-audio utilities", () => {
   describe("calculateDistance", () => {

--- a/src/lib/spatial-audio.ts
+++ b/src/lib/spatial-audio.ts
@@ -14,7 +14,7 @@
  * Range: typically -2.5 to +2.5 in room coordinates
  */
 
-import type { Position, SpatialParams, SoundSource, Speaker, Wall, Room } from "@clippis/types";
+import type { Position, Room, SoundSource, SpatialParams, Speaker, Wall } from "@clippis/types";
 
 /** Musical note frequencies (E4 to G5) */
 export const SOUND_FREQUENCIES = [330, 392, 440, 494, 523, 587, 659, 784] as const;

--- a/src/lib/spatial-utils.test.ts
+++ b/src/lib/spatial-utils.test.ts
@@ -1,22 +1,23 @@
 /**
  * spatial-utils.test.ts - Unit tests for spatial utility functions
  */
-import { describe, it, expect } from "vitest";
-import {
-  toPercent,
-  fromPercent,
-  distanceBetween,
-  angleBetween,
-  normalizeAngle,
-  createWallsFromBounds,
-  createRoomFromCorners,
-  isValidRoomSize,
-  isSpeakerInsideRoom,
-  updateItemById,
-  DEFAULT_ATTENUATION,
-  MIN_ROOM_SIZE,
-} from "@lib/spatial-utils";
+
 import type { DrawnRoom, SpeakerState } from "@clippis/types";
+import {
+  angleBetween,
+  createRoomFromCorners,
+  createWallsFromBounds,
+  DEFAULT_ATTENUATION,
+  distanceBetween,
+  fromPercent,
+  isSpeakerInsideRoom,
+  isValidRoomSize,
+  MIN_ROOM_SIZE,
+  normalizeAngle,
+  toPercent,
+  updateItemById,
+} from "@lib/spatial-utils";
+import { describe, expect, it } from "vitest";
 
 describe("Coordinate Conversion", () => {
   describe("toPercent", () => {

--- a/src/lib/spatial-utils.ts
+++ b/src/lib/spatial-utils.ts
@@ -14,7 +14,7 @@
  * - Y increases downward
  */
 
-import type { Position, Wall, Bounds, DrawnRoom, SpeakerState } from "@clippis/types";
+import type { Bounds, DrawnRoom, Position, SpeakerState, Wall } from "@clippis/types";
 import { createUniqueId } from "solid-js";
 
 // ============================================================================

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,11 +8,12 @@
  *
  * This is the "backend" of the Electron app.
  */
-import { app, BrowserWindow, ipcMain } from "electron";
+
+import fs from "node:fs";
 import path from "node:path";
+import { app, BrowserWindow, ipcMain } from "electron";
 import started from "electron-squirrel-startup";
 import { logger } from "./lib/logger.main";
-import fs from "node:fs";
 
 const settingsPath = path.join(app.getPath("userData"), "settings.json");
 const defaultSettings = {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,16 +9,17 @@
  *
  * Device enumeration requires microphone permission on first load.
  */
-import { createSignal, onMount } from "solid-js";
+
 import type { AudioDevice } from "@clippis/types";
-import { audioStore } from "@stores/audio";
-import { themeStore, type ThemeMode } from "@stores/theme";
-import { useI18n, locales, type Locale } from "@lib/i18n";
 import { Section, SelectField, Slider, Toggle } from "@components/ui";
-import { logger } from "@lib/logger";
-import { showToast } from "@stores/toast";
-import styles from "./Settings.module.css";
 import useHardwareAcceleration from "@lib/hooks/useHardwareAcceleration";
+import { type Locale, locales, useI18n } from "@lib/i18n";
+import { logger } from "@lib/logger";
+import { audioStore } from "@stores/audio";
+import { type ThemeMode, themeStore } from "@stores/theme";
+import { showToast } from "@stores/toast";
+import { createSignal, onMount } from "solid-js";
+import styles from "./Settings.module.css";
 
 export function Settings() {
   const [t, locale, setLocale] = useI18n();

--- a/src/pages/WebRTC.tsx
+++ b/src/pages/WebRTC.tsx
@@ -8,9 +8,10 @@
  *
  * Remote audio plays here un-spatialized; open the Tent page for spatialized playback.
  */
-import { createSignal, createEffect, onCleanup } from "solid-js";
-import styles from "./WebRTC.module.css";
+
 import { webRTCStore } from "@stores/webRTC";
+import { createEffect, createSignal, onCleanup } from "solid-js";
+import styles from "./WebRTC.module.css";
 
 export function WebRTC() {
   const [remoteSdpPaste, setRemoteSdpPaste] = createSignal("");

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,6 +4,7 @@
  * Re-exports all pages for cleaner imports:
  * import { Tent, Settings } from "@/pages"
  */
-export { Tent } from "./Tent";
+
 export { Settings } from "./Settings";
+export { Tent } from "./Tent";
 export { WebRTC } from "./WebRTC";

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -14,14 +14,15 @@
  *   /         -> Tent (spatial audio demo)
  *   /settings -> Settings page
  */
-import { render } from "solid-js/web";
-import { lazy } from "solid-js";
-import { Router, Route } from "@solidjs/router";
+
 import { App } from "@components/layout";
 import { ErrorBoundary, ToastContainer } from "@components/ui";
 import { I18nProvider } from "@lib/i18n";
 import { logger } from "@lib/logger";
+import { Route, Router } from "@solidjs/router";
 import { showToast } from "@stores/toast";
+import { lazy } from "solid-js";
+import { render } from "solid-js/web";
 // Initialize theme store (applies theme before first render)
 import "@stores/theme";
 

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -11,11 +11,12 @@
  *
  * Usage: import { audioStore } from "@/stores/audio"
  */
-import { createSignal, createRoot } from "solid-js";
-import type { SoundSource, Position } from "@clippis/types";
-import { createSoundSource, randomPosition } from "@lib/spatial-audio";
+
+import type { Position, SoundSource } from "@clippis/types";
 import { logger } from "@lib/logger";
+import { createSoundSource, randomPosition } from "@lib/spatial-audio";
 import { showToast } from "@stores/toast";
+import { createRoot, createSignal } from "solid-js";
 
 // Store AudioContext outside of reactive system
 let audioContext: AudioContext | null = null;

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -10,10 +10,11 @@
  * Note: This store avoids createEffect at module level to prevent
  * "computations created outside createRoot" warnings.
  */
-import { createSignal } from "solid-js";
-import type { ThemeMode, ResolvedTheme } from "@clippis/types";
 
-export type { ThemeMode, ResolvedTheme };
+import type { ResolvedTheme, ThemeMode } from "@clippis/types";
+import { createSignal } from "solid-js";
+
+export type { ResolvedTheme, ThemeMode };
 
 /**
  * Get the resolved theme based on current mode and system preference

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -12,10 +12,11 @@
  *   showToast({ type: "success", message: "Saved!" });
  *   showToast({ type: "error", message: "Failed", duration: 5000 });
  */
-import { createSignal, createRoot } from "solid-js";
-import type { Toast, ToastType, ToastOptions } from "@clippis/types";
 
-export type { Toast, ToastType, ToastOptions };
+import type { Toast, ToastOptions, ToastType } from "@clippis/types";
+import { createRoot, createSignal } from "solid-js";
+
+export type { Toast, ToastOptions, ToastType };
 
 const DEFAULT_DURATION = 4000;
 

--- a/src/stores/webRTC.test.ts
+++ b/src/stores/webRTC.test.ts
@@ -11,9 +11,10 @@
  * - Signaling auto-answer flow
  * - Disconnect/cleanup
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { createRoot } from "solid-js";
+
 import { createWebRTCStore, type WebRTCStore } from "@src/stores/webRTC";
+import { createRoot } from "solid-js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Note: logger is mocked globally in src/test/setup.ts
 

--- a/src/stores/webRTC.ts
+++ b/src/stores/webRTC.ts
@@ -1,8 +1,8 @@
-import { createRoot, createSignal, onCleanup } from "solid-js";
-import type { RemotePeerState, DataChannelMessage, Position } from "@clippis/types";
+import type { DataChannelMessage, Position, RemotePeerState } from "@clippis/types";
 import { logger } from "@lib/logger";
-import { showToast } from "@stores/toast";
 import { audioStore } from "@stores/audio";
+import { showToast } from "@stores/toast";
+import { createRoot, createSignal, onCleanup } from "solid-js";
 
 const DEFAULT_ICE_SERVERS = [
   {

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -8,9 +8,10 @@
  * - Code splitting (vendor chunk for solid-js)
  * - Dependency pre-bundling
  */
+
+import path from "node:path";
 import { defineConfig } from "vite";
 import solidPlugin from "vite-plugin-solid";
-import path from "node:path";
 
 // Helper to create absolute paths
 const resolver = (dir: string) => path.resolve(__dirname, dir);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,9 +20,10 @@
  * - Global mocks for Electron APIs (logger, ipc)
  * - Solid-js deduplication prevents multiple instance issues
  */
-import { defineConfig } from "vitest/config";
-import solid from "vite-plugin-solid";
+
 import path from "node:path";
+import solid from "vite-plugin-solid";
+import { defineConfig } from "vitest/config";
 
 // Helper to create absolute paths
 const resolver = (dir: string) => path.resolve(__dirname, dir);


### PR DESCRIPTION
## Summary

The Biome follow-ups from #41, two commits:

**`be36e47` — import/export organizing** (mechanical): `assist.organizeImports` on; imports/exports in 85 files reordered (alphabetical by source, names sorted within statements). One manual touch-up: re-anchoring a section comment in `packages/types/src/index.ts` that the sort orphaned. lint-staged already runs `biome check --write`, so this stays enforced automatically.

**`ff85485` — coverage + strictness**:
- `**/*.js` added to the lint scope — the signaling server had *zero* lint coverage before (old setup was `--ext .ts,.tsx`); it came up clean
- Solid domain `recommended` → `all`: caught the sidebar nav rendering via `.map()`, which makes Solid re-create every nav node on render — now a keyed `<For>`
- `check` script gets `--error-on-warnings`: we're at zero diagnostics, so warnings now block rather than accumulate

## Verification

- `pnpm check` green under the strict flag: tsc 7 typecheck, Biome clean across 130 files, 387 unit tests; UI package 62 tests
- Two-client voice e2e re-run after the 85-file import shuffle (side-effect ordering paranoia): connection, audio both directions, audible RMS, DataChannel position sync — all passing
- Signaling server boots normally post-lint-coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)