### PR TITLE
chore: rename project from Clippi's Tent to TentChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 🎪 Clippi's Tent - Spatial Voice Chat
+# 🎪 TentChat - Spatial Voice Chat
 
 A desktop application prototype recreating **Dolby Axon**-style spatial voice chat functionality. Built with Electron, SolidJS, and Web Audio API.
 
 ## Overview
 
-Clippi's tent demonstrates spatial audio positioning where sound sources have virtual positions in a 2D room. The listener (you) can move around, and audio volume/panning adjusts based on:
+TentChat demonstrates spatial audio positioning where sound sources have virtual positions in a 2D room. The listener (you) can move around, and audio volume/panning adjusts based on:
 
 - **Distance attenuation** — Sounds get quieter as they move further away (linear, inverse, exponential models)
 - **Stereo panning** — Sounds pan left/right based on horizontal position relative to the listener
@@ -54,8 +54,8 @@ Clippi's tent demonstrates spatial audio positioning where sound sources have vi
 
 ```bash
 # Clone the repository
-git clone https://github.com/Omi/clippis_tent.git
-cd clippis_tent
+git clone https://github.com/ohyjek/TentChat.git
+cd TentChat
 
 # Install dependencies
 pnpm install
@@ -106,9 +106,9 @@ pnpm e2e
 This is a **pnpm workspace monorepo** with UI components and types extracted into reusable packages.
 
 ```
-clippis_tent/
+TentChat/
 ├── packages/
-│   ├── ui/                           # @clippis/ui - Reusable UI component library
+│   ├── ui/                           # @tentchat/ui - Reusable UI component library
 │   │   └── src/components/
 │   │       ├── Button/               # Button with variants
 │   │       ├── ColorSwatches/        # Color picker grid
@@ -123,7 +123,7 @@ clippis_tent/
 │   │       ├── Toast/                # Notifications
 │   │       ├── Toggle/               # Checkbox with description
 │   │       └── ErrorBoundary/        # Error boundary
-│   └── types/                        # @clippis/types - Shared TypeScript types
+│   └── types/                        # @tentchat/types - Shared TypeScript types
 ├── src/
 │   ├── main.ts                       # Electron main process
 │   ├── preload.ts                    # Preload script for IPC
@@ -187,7 +187,7 @@ See [docs/TECHNICAL_ROADMAP.md](./docs/TECHNICAL_ROADMAP.md) for the detailed te
 ### ✅ Phase 1: Foundation (Complete)
 
 - [x] Electron + SolidJS + Vite setup
-- [x] UI library extraction to `@clippis/ui` package
+- [x] UI library extraction to `@tentchat/ui` package
 - [x] Spatial audio engine with distance models and directivity patterns
 - [x] Interactive room drawing with wall occlusion
 - [x] Multiple speakers with configurable properties

--- a/docs/TECHNICAL_ROADMAP.md
+++ b/docs/TECHNICAL_ROADMAP.md
@@ -1,6 +1,6 @@
 # Technical Roadmap
 
-This document outlines the technical implementation plan for Clippi's Tent, focusing on completing all audio and voice features before engaging with multiplayer.
+This document outlines the technical implementation plan for TentChat, focusing on completing all audio and voice features before engaging with multiplayer.
 
 ## Current State (Phase 1 Complete)
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; media-src 'self' blob:; connect-src 'self' ws://localhost:* http://localhost:*"
     />
-    <title>Clippis - Spatial Voice Chat</title>
+    <title>TentChat - Spatial Voice Chat</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "clippis_tent",
-  "productName": "clippis_tent",
+  "name": "tentchat",
+  "productName": "TentChat",
   "version": "1.0.0",
   "description": "Spatial voice chat prototype inspired by Dolby Axon",
   "main": ".vite/build/main.js",
@@ -27,7 +27,7 @@
     "test:coverage": "vitest run --coverage",
     "test:hooks": "vitest run src/lib/hooks",
     "test:spatial": "vitest run src/lib/spatial",
-    "test:ui": "pnpm --filter @clippis/ui test",
+    "test:ui": "pnpm --filter @tentchat/ui test",
     "test:all": "pnpm test && pnpm e2e",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
@@ -78,8 +78,8 @@
     "vitest": "^4.1.9"
   },
   "dependencies": {
-    "@clippis/types": "workspace:*",
-    "@clippis/ui": "workspace:*",
+    "@tentchat/types": "workspace:*",
+    "@tentchat/ui": "workspace:*",
     "@solid-primitives/i18n": "^2.2.1",
     "@solidjs/router": "^0.16.1",
     "electron-log": "^5.4.4",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@clippis/types",
+  "name": "@tentchat/types",
   "version": "0.1.0",
-  "description": "Shared TypeScript types for Clippis",
+  "description": "Shared TypeScript types for TentChat",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@clippis/ui",
+  "name": "@tentchat/ui",
   "version": "0.1.0",
-  "description": "Reusable UI component library for Clippis",
+  "description": "Reusable UI component library for TentChat",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "sideEffects": [
@@ -16,7 +16,7 @@
     "solid-js": "^1.9.0"
   },
   "dependencies": {
-    "@clippis/types": "workspace:*"
+    "@tentchat/types": "workspace:*"
   },
   "devDependencies": {
     "@solidjs/testing-library": "^0.8.10",

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -11,7 +11,7 @@
  * <Button icon="✕" aria-label="Close" onClick={close} />
  */
 
-import type { ButtonVariant } from "@clippis/types";
+import type { ButtonVariant } from "@tentchat/types";
 import { type JSX, splitProps } from "solid-js";
 import styles from "./Button.module.css";
 

--- a/packages/ui/src/components/ItemList/ItemList.tsx
+++ b/packages/ui/src/components/ItemList/ItemList.tsx
@@ -12,11 +12,11 @@
  * />
  */
 
-import type { ListItem } from "@clippis/types";
+import type { ListItem } from "@tentchat/types";
 import { For, type JSX, Show } from "solid-js";
 import styles from "./ItemList.module.css";
 
-/** @deprecated Use ListItem from @clippis/types instead */
+/** @deprecated Use ListItem from @tentchat/types instead */
 export type ItemListItem = ListItem;
 
 export interface ItemListProps {

--- a/packages/ui/src/components/SelectField/SelectField.tsx
+++ b/packages/ui/src/components/SelectField/SelectField.tsx
@@ -12,7 +12,7 @@
  * />
  */
 
-import type { SelectOption } from "@clippis/types";
+import type { SelectOption } from "@tentchat/types";
 import { createUniqueId, For, type JSX, splitProps } from "solid-js";
 import styles from "./SelectField.module.css";
 

--- a/packages/ui/src/components/Speaker/Speaker.tsx
+++ b/packages/ui/src/components/Speaker/Speaker.tsx
@@ -11,7 +11,7 @@
  * Used in FullDemo for both speakers and the listener.
  */
 
-import type { Position } from "@clippis/types";
+import type { Position } from "@tentchat/types";
 import type { JSX } from "solid-js";
 import styles from "./Speaker.module.css";
 

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -15,7 +15,7 @@
  * />
  */
 
-import type { Tab } from "@clippis/types";
+import type { Tab } from "@tentchat/types";
 import { createSignal, For } from "solid-js";
 import styles from "./Tabs.module.css";
 

--- a/packages/ui/src/components/Toast/Toast.tsx
+++ b/packages/ui/src/components/Toast/Toast.tsx
@@ -8,7 +8,7 @@
  * <ToastContainer toasts={toasts()} onDismiss={dismissToast} />
  */
 
-import type { ToastData, ToastType } from "@clippis/types";
+import type { ToastData, ToastType } from "@tentchat/types";
 import { For } from "solid-js";
 import styles from "./Toast.module.css";
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * @clippis/ui - Reusable UI component library
+ * @tentchat/ui - Reusable UI component library
  *
  * A collection of SolidJS UI components with consistent styling.
  * Components use CSS Modules and CSS custom properties (variables).
  *
  * @example
- * import { Button, Slider, ToastContainer } from "@clippis/ui";
+ * import { Button, Slider, ToastContainer } from "@tentchat/ui";
  */
 export * from "./components";

--- a/packages/ui/test/setup.ts
+++ b/packages/ui/test/setup.ts
@@ -1,5 +1,5 @@
 /**
- * test/setup.ts - Test setup for @clippis/ui
+ * test/setup.ts - Test setup for @tentchat/ui
  *
  * Configures testing environment with jest-dom matchers and
  * provides mock CSS variables for component styling.

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,5 +1,5 @@
 /**
- * vitest.config.ts - Test configuration for @clippis/ui
+ * vitest.config.ts - Test configuration for @tentchat/ui
  *
  * Configures Vitest with jsdom environment for component testing.
  * Note: Tests are typically run from the root monorepo for better deduplication.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,18 +14,18 @@ importers:
 
   .:
     dependencies:
-      '@clippis/types':
-        specifier: workspace:*
-        version: link:packages/types
-      '@clippis/ui':
-        specifier: workspace:*
-        version: link:packages/ui
       '@solid-primitives/i18n':
         specifier: ^2.2.1
         version: 2.2.1(solid-js@1.9.14)
       '@solidjs/router':
         specifier: ^0.16.1
         version: 0.16.1(solid-js@1.9.14)
+      '@tentchat/types':
+        specifier: workspace:*
+        version: link:packages/types
+      '@tentchat/ui':
+        specifier: workspace:*
+        version: link:packages/ui
       electron-log:
         specifier: ^5.4.4
         version: 5.4.4
@@ -126,7 +126,7 @@ importers:
 
   packages/ui:
     dependencies:
-      '@clippis/types':
+      '@tentchat/types':
         specifier: workspace:*
         version: link:../types
       solid-js:

--- a/src/components/audio/FullDemo/components/panels/AudioSettingsPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/AudioSettingsPanel.tsx
@@ -4,10 +4,10 @@
  * Contains perspective selection, distance model, max distance, rear gain, and visual settings.
  */
 
-import type { DistanceModel } from "@clippis/types";
 import { DISTANCE_MODEL_OPTIONS } from "@components/audio/FullDemo/constants";
 import { useDemoContext } from "@components/audio/FullDemo/context";
 import { DropdownField, FieldGroup, Panel, SliderField, Toggle } from "@components/ui";
+import type { DistanceModel } from "@tentchat/types";
 import { For, Index } from "solid-js";
 
 export function AudioSettingsPanel() {

--- a/src/components/audio/FullDemo/components/panels/SpeakerPropertiesPanel.tsx
+++ b/src/components/audio/FullDemo/components/panels/SpeakerPropertiesPanel.tsx
@@ -4,7 +4,6 @@
  * Allows changing source type (oscillator/microphone), directivity pattern, frequency, and color.
  */
 
-import type { AudioSourceType, DirectivityPattern } from "@clippis/types";
 import { DIRECTIVITY_OPTIONS, SOURCE_TYPE_OPTIONS } from "@components/audio/FullDemo/constants";
 import { useDemoContext } from "@components/audio/FullDemo/context";
 import { getNoteName } from "@components/audio/FullDemo/utils";
@@ -18,6 +17,7 @@ import {
   SliderField,
 } from "@components/ui";
 import { SPEAKER_COLORS } from "@lib/spatial-audio";
+import type { AudioSourceType, DirectivityPattern } from "@tentchat/types";
 import { For, Show } from "solid-js";
 
 export function SpeakerPropertiesPanel() {

--- a/src/components/audio/FullDemo/context/DemoContext.tsx
+++ b/src/components/audio/FullDemo/context/DemoContext.tsx
@@ -5,7 +5,6 @@
  * Composes specialized hooks for room, speaker, audio, and interaction management.
  */
 
-import type { DistanceModel } from "@clippis/types";
 import {
   useAudioPlayback,
   useCanvasDrawing,
@@ -20,6 +19,7 @@ import { isSpeakerInsideRoom } from "@lib/spatial-utils";
 import { audioStore } from "@stores/audio";
 import { showToast } from "@stores/toast";
 import { webRTCStore } from "@stores/webRTC";
+import type { DistanceModel } from "@tentchat/types";
 import {
   createContext,
   createEffect,

--- a/src/components/audio/FullDemo/context/types.ts
+++ b/src/components/audio/FullDemo/context/types.ts
@@ -1,12 +1,13 @@
 /**
  * types.ts - Type re-exports for the spatial audio demo
  *
- * Re-exports commonly used types from @clippis/types for convenience.
- * All types are defined in the shared @clippis/types package.
+ * Re-exports commonly used types from @tentchat/types for convenience.
+ * All types are defined in the shared @tentchat/types package.
  *
- * We do this because if we have to change from @clippis/types to a different package, we only have to change it in one place.
+ * We do this because if we have to change from @tentchat/types to a different package, we only have to change it in one place.
  */
 
+import type { CalculateAudioParameters } from "@lib/spatial-audio-engine";
 import type {
   AudioNodes,
   AudioParameters,
@@ -21,8 +22,7 @@ import type {
   SelectOption,
   SpeakerState,
   Wall,
-} from "@clippis/types";
-import type { CalculateAudioParameters } from "@lib/spatial-audio-engine";
+} from "@tentchat/types";
 import type { Accessor, Setter } from "solid-js";
 
 /** Context value type - exposes all state and actions to components */

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,11 +1,11 @@
 /**
  * ErrorBoundary.tsx - App-level ErrorBoundary wrapper
  *
- * Wraps the @clippis/ui ErrorBoundary with app-specific error logging.
+ * Wraps the @tentchat/ui ErrorBoundary with app-specific error logging.
  */
 
-import { ErrorBoundary as UIErrorBoundary } from "@clippis/ui";
 import { logger } from "@lib/logger";
+import { ErrorBoundary as UIErrorBoundary } from "@tentchat/ui";
 import type { JSX } from "solid-js";
 
 interface ErrorBoundaryProps {

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,14 +1,15 @@
 /**
  * Toast.tsx - App-level Toast wrapper
  *
- * Connects the @clippis/ui ToastContainer to the app's toast store.
+ * Connects the @tentchat/ui ToastContainer to the app's toast store.
  * Re-exports everything from the UI library for convenience.
  */
-import { ToastContainer as UIToastContainer } from "@clippis/ui";
+
 import { dismissToast, toasts } from "@stores/toast";
+import { ToastContainer as UIToastContainer } from "@tentchat/ui";
 
 // Re-export the type from the UI library
-export type { ToastData, ToastType } from "@clippis/ui";
+export type { ToastData, ToastType } from "@tentchat/ui";
 
 /**
  * App-specific ToastContainer that connects to the toast store.

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,14 +1,14 @@
 /**
  * ui/index.ts - UI component exports
  *
- * Re-exports UI components from @clippis/ui and app-specific wrappers.
+ * Re-exports UI components from @tentchat/ui and app-specific wrappers.
  * Most components come directly from the UI library, while ErrorBoundary
  * and ToastContainer have app-specific wrappers that add logging.
  *
  * Usage: import { Button, Slider, Tabs } from "@/components/ui"
  */
 
-// Pure UI components from @clippis/ui
+// Pure UI components from @tentchat/ui
 export {
   Button,
   ButtonRow,
@@ -34,7 +34,7 @@ export {
   type Tab,
   Tabs,
   Toggle,
-} from "@clippis/ui";
+} from "@tentchat/ui";
 
 // App-specific wrappers (with logging integration)
 export { ErrorBoundary } from "./ErrorBoundary";

--- a/src/lib/hooks/useAudioPlayback.ts
+++ b/src/lib/hooks/useAudioPlayback.ts
@@ -4,8 +4,8 @@
  * Manages audio nodes for multiple speakers with real-time parameter updates.
  */
 
-import type { AudioNodes, AudioSourceType } from "@clippis/types";
 import { audioStore } from "@stores/audio";
+import type { AudioNodes, AudioSourceType } from "@tentchat/types";
 import { type Accessor, createSignal, onCleanup } from "solid-js";
 
 export type { AudioNodes };

--- a/src/lib/hooks/useCanvasDrawing.ts
+++ b/src/lib/hooks/useCanvasDrawing.ts
@@ -4,7 +4,7 @@
  * Handles draw mode mouse events for creating rectangular regions.
  */
 
-import type { DrawingMode, Position } from "@clippis/types";
+import type { DrawingMode, Position } from "@tentchat/types";
 import { type Accessor, createSignal, type Setter } from "solid-js";
 
 /** Options for canvas drawing */

--- a/src/lib/hooks/useRemoteSpeaker.ts
+++ b/src/lib/hooks/useRemoteSpeaker.ts
@@ -6,16 +6,16 @@
  * remote position, the listener, walls, or audio settings change.
  */
 
+import { logger } from "@lib/logger";
+import { calculateAudioParameters } from "@lib/spatial-audio-engine";
+import { audioStore } from "@stores/audio";
 import type {
   AudioParameterOptions,
   AudioParameters,
   Listener,
   Position,
   Wall,
-} from "@clippis/types";
-import { logger } from "@lib/logger";
-import { calculateAudioParameters } from "@lib/spatial-audio-engine";
-import { audioStore } from "@stores/audio";
+} from "@tentchat/types";
 import { type Accessor, createEffect, createMemo, createSignal, onCleanup } from "solid-js";
 
 export interface RemoteSpeakerOptions {

--- a/src/lib/hooks/useRoomManager.ts
+++ b/src/lib/hooks/useRoomManager.ts
@@ -4,13 +4,13 @@
  * Provides room CRUD operations and selection state.
  */
 
-import type { DrawnRoom, Position, Wall } from "@clippis/types";
 import {
   createRoomFromCorners,
   DEFAULT_ATTENUATION,
   isValidRoomSize,
   updateItemById,
 } from "@lib/spatial-utils";
+import type { DrawnRoom, Position, Wall } from "@tentchat/types";
 import { type Accessor, createSignal, type Setter } from "solid-js";
 
 /** Room creation configuration */

--- a/src/lib/hooks/useSpeakerManager.test.ts
+++ b/src/lib/hooks/useSpeakerManager.test.ts
@@ -2,8 +2,8 @@
  * useSpeakerManager.test.ts - Unit tests for speaker management hook
  */
 
-import type { SpeakerState } from "@clippis/types";
 import { type SpeakerManagerState, useSpeakerManager } from "@lib/hooks/useSpeakerManager";
+import type { SpeakerState } from "@tentchat/types";
 import { createRoot } from "solid-js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/src/lib/hooks/useSpeakerManager.ts
+++ b/src/lib/hooks/useSpeakerManager.ts
@@ -4,9 +4,9 @@
  * Provides speaker CRUD operations, selection, and perspective management.
  */
 
-import type { AudioSourceType, DirectivityPattern, Position, SpeakerState } from "@clippis/types";
 import { SPEAKER_COLORS } from "@lib/spatial-audio";
 import { generateId, updateItemById } from "@lib/spatial-utils";
+import type { AudioSourceType, DirectivityPattern, Position, SpeakerState } from "@tentchat/types";
 import { type Accessor, createSignal, type Setter } from "solid-js";
 
 /** Options for speaker manager initialization */

--- a/src/lib/spatial-audio-engine.ts
+++ b/src/lib/spatial-audio-engine.ts
@@ -12,6 +12,13 @@
  * Uses Web Audio API for actual sound generation.
  */
 
+import {
+  calculateAngleToPoint,
+  calculateDistance,
+  calculateWallAttenuation,
+  countWallsBetween,
+  normalizeAngle,
+} from "@lib/spatial-audio";
 import type {
   AudioParameterOptions,
   AudioParameters,
@@ -21,15 +28,7 @@ import type {
   Position,
   SourceConfig,
   Wall,
-} from "@clippis/types";
-
-import {
-  calculateAngleToPoint,
-  calculateDistance,
-  calculateWallAttenuation,
-  countWallsBetween,
-  normalizeAngle,
-} from "@lib/spatial-audio";
+} from "@tentchat/types";
 
 // ============================================================================
 // RETURN TYPE EXPORTS

--- a/src/lib/spatial-audio.ts
+++ b/src/lib/spatial-audio.ts
@@ -14,7 +14,7 @@
  * Range: typically -2.5 to +2.5 in room coordinates
  */
 
-import type { Position, Room, SoundSource, SpatialParams, Speaker, Wall } from "@clippis/types";
+import type { Position, Room, SoundSource, SpatialParams, Speaker, Wall } from "@tentchat/types";
 
 /** Musical note frequencies (E4 to G5) */
 export const SOUND_FREQUENCIES = [330, 392, 440, 494, 523, 587, 659, 784] as const;

--- a/src/lib/spatial-utils.test.ts
+++ b/src/lib/spatial-utils.test.ts
@@ -2,7 +2,6 @@
  * spatial-utils.test.ts - Unit tests for spatial utility functions
  */
 
-import type { DrawnRoom, SpeakerState } from "@clippis/types";
 import {
   angleBetween,
   createRoomFromCorners,
@@ -17,6 +16,7 @@ import {
   toPercent,
   updateItemById,
 } from "@lib/spatial-utils";
+import type { DrawnRoom, SpeakerState } from "@tentchat/types";
 import { describe, expect, it } from "vitest";
 
 describe("Coordinate Conversion", () => {

--- a/src/lib/spatial-utils.ts
+++ b/src/lib/spatial-utils.ts
@@ -14,7 +14,7 @@
  * - Y increases downward
  */
 
-import type { Bounds, DrawnRoom, Position, SpeakerState, Wall } from "@clippis/types";
+import type { Bounds, DrawnRoom, Position, SpeakerState, Wall } from "@tentchat/types";
 import { createUniqueId } from "solid-js";
 
 // ============================================================================

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,6 @@
 {
   "app": {
-    "name": "Clippi's Tent",
+    "name": "TentChat",
     "tagline": "Spatial Voice Chat"
   },
   "nav": {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,7 +10,6 @@
  * Device enumeration requires microphone permission on first load.
  */
 
-import type { AudioDevice } from "@clippis/types";
 import { Section, SelectField, Slider, Toggle } from "@components/ui";
 import useHardwareAcceleration from "@lib/hooks/useHardwareAcceleration";
 import { type Locale, locales, useI18n } from "@lib/i18n";
@@ -18,6 +17,7 @@ import { logger } from "@lib/logger";
 import { audioStore } from "@stores/audio";
 import { type ThemeMode, themeStore } from "@stores/theme";
 import { showToast } from "@stores/toast";
+import type { AudioDevice } from "@tentchat/types";
 import { createSignal, onMount } from "solid-js";
 import styles from "./Settings.module.css";
 

--- a/src/stores/audio.ts
+++ b/src/stores/audio.ts
@@ -12,10 +12,10 @@
  * Usage: import { audioStore } from "@/stores/audio"
  */
 
-import type { Position, SoundSource } from "@clippis/types";
 import { logger } from "@lib/logger";
 import { createSoundSource, randomPosition } from "@lib/spatial-audio";
 import { showToast } from "@stores/toast";
+import type { Position, SoundSource } from "@tentchat/types";
 import { createRoot, createSignal } from "solid-js";
 
 // Store AudioContext outside of reactive system

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -11,7 +11,7 @@
  * "computations created outside createRoot" warnings.
  */
 
-import type { ResolvedTheme, ThemeMode } from "@clippis/types";
+import type { ResolvedTheme, ThemeMode } from "@tentchat/types";
 import { createSignal } from "solid-js";
 
 export type { ResolvedTheme, ThemeMode };

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -13,7 +13,7 @@
  *   showToast({ type: "error", message: "Failed", duration: 5000 });
  */
 
-import type { Toast, ToastOptions, ToastType } from "@clippis/types";
+import type { Toast, ToastOptions, ToastType } from "@tentchat/types";
 import { createRoot, createSignal } from "solid-js";
 
 export type { Toast, ToastOptions, ToastType };

--- a/src/stores/webRTC.ts
+++ b/src/stores/webRTC.ts
@@ -1,7 +1,7 @@
-import type { DataChannelMessage, Position, RemotePeerState } from "@clippis/types";
 import { logger } from "@lib/logger";
 import { audioStore } from "@stores/audio";
 import { showToast } from "@stores/toast";
+import type { DataChannelMessage, Position, RemotePeerState } from "@tentchat/types";
 import { createRoot, createSignal, onCleanup } from "solid-js";
 
 const DEFAULT_ICE_SERVERS = [

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -47,8 +47,8 @@ export default defineConfig(({ mode }) => ({
       "@styles": resolver("./src/styles"),
 
       // Workspace packages (resolve to source for HMR)
-      "@clippis/ui": resolver("./packages/ui/src"),
-      "@clippis/types": resolver("./packages/types/src"),
+      "@tentchat/ui": resolver("./packages/ui/src"),
+      "@tentchat/types": resolver("./packages/types/src"),
     },
   },
   build: {
@@ -63,7 +63,7 @@ export default defineConfig(({ mode }) => ({
           // Vendor chunk for framework code
           "solid-vendor": ["solid-js", "solid-js/web", "@solidjs/router"],
           // Workspace chunks for shared dependencies
-          workspace: ["@clippis/ui", "@clippis/types"],
+          workspace: ["@tentchat/ui", "@tentchat/types"],
         },
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,8 +44,8 @@ export default defineConfig({
       "solid-js/store": resolver("node_modules/solid-js/store"),
       "solid-js": resolver("node_modules/solid-js"),
       // Resolve UI package to source for better DX
-      "@clippis/ui": resolver("packages/ui/src"),
-      "@clippis/types": resolver("packages/types/src"),
+      "@tentchat/ui": resolver("packages/ui/src"),
+      "@tentchat/types": resolver("packages/types/src"),
       // App source alias
       "@src/": resolver("src/"),
       "@src": resolver("src"),


### PR DESCRIPTION
Full rebrand following the GitHub repo rename (already done — old URLs redirect):

- npm workspace scope `@clippis/*` → `@tentchat/*` (package names, imports, vite/vitest aliases, lockfile)
- Root package `name` → `tentchat`, Electron `productName` → `TentChat`
- Window title, i18n app name, README, technical roadmap
- Biome import re-sort (scope rename changed alphabetical order of 16 files' imports)
- Drive-by fix: README clone URL pointed at `github.com/Omi/…` (wrong username)

Verified: typecheck, biome check, and 387/387 tests pass.