### PR TITLE
chore: upgrade pnpm to 11 (from 10.28.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ out/
 playwright-report/
 test-results/
 blob-report/
+# Claude agent worktrees (full checkouts; never commit)
+.claude/worktrees/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# pnpm-specific config (npm may warn about this, but it's harmless)
-node-linker = hoisted

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -12,6 +12,9 @@
       "**/*.jsonc",
       "**/*.css",
       "!**/node_modules",
+      // Claude agent worktrees live under .claude/worktrees — each contains a full
+      // checkout with its own root biome config, which trips nested-root detection.
+      "!**/.claude",
       "!**/.vite",
       "!**/out",
       "!**/dist",

--- a/package.json
+++ b/package.json
@@ -39,13 +39,6 @@
   "keywords": [],
   "author": "Omi",
   "license": "MIT",
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "electron",
-      "electron-winstaller",
-      "esbuild"
-    ]
-  },
   "devDependencies": {
     "@biomejs/biome": "2.5.2",
     "@electron-forge/cli": "^7.11.2",
@@ -81,5 +74,5 @@
     "solid-js": "^1.9.14",
     "webrtc-adapter": "^9.0.6"
   },
-  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,7 +450,7 @@ packages:
     engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -1601,8 +1601,8 @@ packages:
   electron-squirrel-startup@1.0.1:
     resolution: {integrity: sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==}
 
-  electron-to-chromium@1.5.386:
-    resolution: {integrity: sha512-f9yJE+9dJy+B4QC1iTu+mVP/KWLZviG5u/qtRwdBF0zPt3etWa1HSY1lMuWw0Nt8/KpLCY6ok+XlKHOs6ZhxSA==}
+  electron-to-chromium@1.5.385:
+    resolution: {integrity: sha512-78sa/M08MNAYHQfjoWMvOlKQqZ0ElhSm/L5HNUc96VZ3b+KvDVnngFm8sYQy0XrhTRgAhggHr5abA7yTvRdo4Q==}
 
   electron-winstaller@5.4.4:
     resolution: {integrity: sha512-j9ETcBGJaXxAY/b6UBpR7LZfjdU4BAO+yvr4ifqHEdyuc3UNCy91PDGkWKY5UQ4coHNYfnwFggrqD6QPeFGAlg==}
@@ -4615,7 +4615,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.10.41
       caniuse-lite: 1.0.30001800
-      electron-to-chromium: 1.5.386
+      electron-to-chromium: 1.5.385
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
@@ -4876,7 +4876,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-to-chromium@1.5.386: {}
+  electron-to-chromium@1.5.385: {}
 
   electron-winstaller@5.4.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,23 @@ catalog:
   # TS 7 RC (native Go compiler) — exact prerelease pin, deduped workspace-wide.
   # Flip to stable at 7.0 GA (~mid-July 2026); verified fallback: 6.0.3.
   typescript: 7.0.1-rc
+
+# pnpm 11 reads settings from here — .npmrc and package.json#pnpm are no longer honored.
+
+# Flat npm-like node_modules; Electron Forge packaging expects this layout.
+nodeLinker: hoisted
+
+# Replaces onlyBuiltDependencies (removed in pnpm 11): postinstall scripts are
+# blocked unless allowed here.
+allowBuilds:
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+
+# @electron/rebuild (via electron-forge) depends on @electron/node-gyp as a GitHub
+# tarball — not published to npm — which this policy rejects on any re-resolution.
+# Re-enable once upstream publishes @electron/node-gyp to the registry.
+blockExoticSubdeps: false
+
+
+


### PR DESCRIPTION
Upgrades the corepack pin to **pnpm 11.9.0** and migrates everything the major requires.

## Config migrations
- **`.npmrc` deleted** — pnpm 11 only reads auth/registry settings from npmrc; `node-linker = hoisted` moves to `pnpm-workspace.yaml` as `nodeLinker: hoisted`
- **`package.json#pnpm` removed** — the field is no longer read; `onlyBuiltDependencies` (removed in 11) becomes the new `allowBuilds` map (electron, electron-winstaller, esbuild)
- **`blockExoticSubdeps: false`** — the new default blocks git/tarball *transitive* deps, but `@electron/rebuild` (via electron-forge) depends on `@electron/node-gyp` as a GitHub tarball that upstream has never published to npm. Documented with a TODO to re-enable. No allowlist mechanism exists for this setting.
- **`electron-to-chromium` 1.5.386 → 1.5.385** — 1.5.386 was published <24h ago and the new `minimumReleaseAge` default (24h supply-chain gate, kept enabled) rejects it. 1.5.385 is what a fresh resolution under the policy picks anyway.

## Also included
- Biome now excludes `.claude/`: agent worktrees under `.claude/worktrees/` contain full checkouts whose root Biome config trips nested-root detection (surfaced by the json/jsonc coverage expansion). Also gitignored.
- Rides along: the local `chore(biome): cover JSON and CSS` commit from main that predated this branch.

## Verified
- `pnpm install` passes the default supply-chain verification (714 entries)
- Hoisted layout confirmed (flat node_modules, `.modules.yaml` says `nodeLinker: hoisted`)
- `pnpm check`: typecheck + Biome + 387/387 tests
- `pnpm package`: full Electron Forge packaging incl. native-deps rebuild → `out/TentChat-linux-x64`

Note for other machines: first install under 11 purges node_modules (store v11) — run with `CI=true` in non-TTY contexts.